### PR TITLE
docs: refine Agent Skills copy in profile README [HOLD until 7/14]

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -14,6 +14,8 @@ We’re building AI infrastructure tools to help edtech tools align more closely
 
 [Evaluators](https://github.com/learning-commons-org/evaluators): Assess the instructional quality of educational AI outputs through research-backed educational rubrics and expert-designed scoring systems. With standardized evaluation frameworks and metrics, these tools help assess whether AI-generated content meets high standards of accuracy, pedagogical soundness, and effectiveness.
 
+[Agent Skills](https://github.com/learning-commons-org/agent-skills): Produce classroom-ready, standards-aligned K-12 teaching materials through open AI skills that encode strong instructional practice into common teacher workflows. Each skill gives an AI agent the instructions and guardrails it needs to produce consistent, reliable results. They work on their own, and get better whenh connected to Knowledge Graph.
+
 [Learning Commons Platform](https://platform.learningcommons.org): Get API keys for Knowledge Graph's API and MCP server, see how datasets connect in the Knowledge Graph Explorer, and run your own text through the Evaluators Playground.
 
 [Learn more](https://learningcommons.org/for-developers/?utm_source=github&utm_medium=overview) about our developer tools. 

--- a/profile/README.md
+++ b/profile/README.md
@@ -14,7 +14,7 @@ We’re building AI infrastructure tools to help edtech tools align more closely
 
 [Evaluators](https://github.com/learning-commons-org/evaluators): Assess the instructional quality of educational AI outputs through research-backed educational rubrics and expert-designed scoring systems. With standardized evaluation frameworks and metrics, these tools help assess whether AI-generated content meets high standards of accuracy, pedagogical soundness, and effectiveness.
 
-[Agent Skills](https://github.com/learning-commons-org/agent-skills): Produce classroom-ready, standards-aligned K-12 teaching materials through open AI skills that encode strong instructional practice into common teacher workflows. Each skill gives an AI agent the instructions and guardrails it needs to produce consistent, reliable results. They work on their own, and get better whenh connected to Knowledge Graph.
+[Agent Skills](https://github.com/learning-commons-org/agent-skills): Produce high-quality, standards-aligned teaching materials through open skills that encode strong instructional practice into common teacher workflows. Each skill packages the instructions, references, and guardrails an AI agent needs to reliably complete a teacher task, producing consistent, classroom-ready results. Grounded in learning science, the skills work on their own and get better when connected to Knowledge Graph.
 
 [Learning Commons Platform](https://platform.learningcommons.org): Get API keys for Knowledge Graph's API and MCP server, see how datasets connect in the Knowledge Graph Explorer, and run your own text through the Evaluators Playground.
 


### PR DESCRIPTION
## Summary
Refines the Agent Skills paragraph in the org profile README.

- Aligns wording with the [agent-skills repo README](https://github.com/learning-commons-org/agent-skills) — "open skills", "packages the instructions, references, and guardrails", "classroom-ready results", "grounded in learning science".
- Drops "K-12" (not a term we commonly use across surfaces).
- Fixes a typo ("whenh" → "when").

## ⚠️ Do not merge until 2026-07-14
Opened as a **draft** and held per coordinated release timing. Mark ready for review on/after 7/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)